### PR TITLE
Support exportEvents

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -1,11 +1,7 @@
-import { createBuffer } from '@posthog/plugin-contrib'
-import { Plugin, PluginMeta } from '@posthog/plugin-scaffold'
+import { Plugin } from '@posthog/plugin-scaffold'
 import fetch from 'node-fetch'
 
-export interface ReplicatorMeta extends PluginMeta {
-    global: {
-        buffer: ReturnType<typeof createBuffer>
-    }
+export interface ReplicatorMetaInput {
     config: {
         host: string
         project_api_key: string
@@ -13,35 +9,26 @@ export interface ReplicatorMeta extends PluginMeta {
     }
 }
 
-const plugin: Plugin<ReplicatorMeta> = {
-    setupPlugin: ({ global, config }) => {
-        global.buffer = createBuffer({
-            limit: 1024 * 1024, // 1 MB
-            timeoutSeconds: 1,
-            onFlush: async (batch) => {
-                await fetch(`https://${config.host}/e`, {
-                    method: 'POST',
-                    body: JSON.stringify(batch),
-                    headers: { 'Content-Type': 'application/json' },
-                })
-                console.log(`Flushing ${batch.length} event${batch.length > 1 ? 's' : ''} to ${config.host}`)
-            },
-        })
-    },
-
-    teardownPlugin: ({ global }) => {
-        global.buffer.flush()
-    },
-
-    processEvent: async (event, { config, global }) => {
-        // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { team_id, now, offset, ...sendableEvent } = { ...event, token: config.project_api_key }
-        const sendableEventSize = JSON.stringify(sendableEvent).length
-        const replication = parseInt(config.replication) || 1
-        for (let i = 0; i < replication; i++) {
-            global.buffer.add(sendableEvent, sendableEventSize)
+const plugin: Plugin<ReplicatorMetaInput> = {
+    exportEvents: async (events, { config }) => {
+        const batch = []
+        for (const event of events) {
+            // eslint-disable-next-line @typescript-eslint/no-unused-vars
+            const { team_id, now, offset, ...sendableEvent } = { ...event, token: config.project_api_key }
+            const replication = parseInt(config.replication) || 1
+            for (let i = 0; i < replication; i++) {
+                batch.push(sendableEvent)
+            }
         }
-        return event
+
+        if (batch.length > 0) {
+            await fetch(`https://${config.host}/e`, {
+                method: 'POST',
+                body: JSON.stringify(batch),
+                headers: { 'Content-Type': 'application/json' },
+            })
+            console.log(`Flushing ${batch.length} event${batch.length > 1 ? 's' : ''} to ${config.host}`)
+        }
     },
 }
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-plugin-replicator",
-    "version": "1.0.0",
+    "version": "1.1.0",
     "description": "Replicate PostHog event stream in another PostHog instance",
     "keywords": [
         "posthog",

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "dependencies": {},
     "devDependencies": {
         "@posthog/plugin-contrib": "^0.0.3",
-        "@posthog/plugin-scaffold": "0.6.0",
+        "@posthog/plugin-scaffold": "~0.12.9",
         "@types/jest": "^26.0.19",
         "@types/node-fetch": "^2.5.10",
         "@typescript-eslint/eslint-plugin": "^4.12.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -508,16 +508,6 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@maxmind/geoip2-node@^2.3.1":
-  version "2.3.1"
-  resolved "https://registry.yarnpkg.com/@maxmind/geoip2-node/-/geoip2-node-2.3.1.tgz#f465bfec300b9a24ce14fc1acdd2b0d931b5674a"
-  integrity sha512-iWxQiymqUJeZOm2GibQlOebZgEFly6SvTL1iALennYGPAsbBX+Iu50tz6xFGsO+2uoohDjPglx0h2TFZO7N2kQ==
-  dependencies:
-    camelcase-keys "^6.0.1"
-    ip6addr "^0.2.3"
-    lodash.set "^4.3.2"
-    maxmind "^4.2.0"
-
 "@nodelib/fs.scandir@2.1.4":
   version "2.1.4"
   resolved "https://registry.yarnpkg.com/@nodelib/fs.scandir/-/fs.scandir-2.1.4.tgz#d4b3549a5db5de2683e0c1071ab4f140904bbf69"
@@ -544,12 +534,10 @@
   resolved "https://registry.yarnpkg.com/@posthog/plugin-contrib/-/plugin-contrib-0.0.3.tgz#d0772c6dd9ec9944ebee9dc475e1e781256b0b5f"
   integrity sha512-0HrE8AuPv3OLZA93RrJDbljn9u5D/wmiIkBCeckU3LL67LNozDIJgKsY4Td91zgc+b4Rlx/X0MJNp2l6BHbQqg==
 
-"@posthog/plugin-scaffold@0.6.0":
-  version "0.6.0"
-  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.6.0.tgz#4dc47ebe74f6a3e536aeb610b6c132c6d0a23e85"
-  integrity sha512-CxyCU+f19NNsOJNN3dAYBcHtoAsfsDMCWE3+Y/DCjDPDiijgEdSKRSMlaoZHCSIdRwBtXSXjaYTLMD1I6HIbug==
-  dependencies:
-    "@maxmind/geoip2-node" "^2.3.1"
+"@posthog/plugin-scaffold@~0.12.9":
+  version "0.12.9"
+  resolved "https://registry.yarnpkg.com/@posthog/plugin-scaffold/-/plugin-scaffold-0.12.9.tgz#7d1e6f07ccc5d72c657ecbf004846a4a4b241bbc"
+  integrity sha512-W969xOjlMrWx3kUbRP6hKD85y+UExiYhTRrgISSy0ZorH/vhErJ69a6RPGzDdlIh1Blc6JMvwLffZg1ZPdssbA==
 
 "@sinonjs/commons@^1.7.0":
   version "1.8.2"
@@ -1138,15 +1126,6 @@ callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
   integrity sha512-P8BjAsXvZS+VIDUI11hHCQEv74YT67YUi5JJFNWIqL235sBmjX4+qx9Muvls5ivyNENctx46xQLQ3aTuE7ssaQ==
-
-camelcase-keys@^6.0.1:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/camelcase-keys/-/camelcase-keys-6.2.2.tgz#5e755d6ba51aa223ec7d3d52f25778210f9dc3c0"
-  integrity sha512-YrwaA0vEKazPBkn0ipTiMpSajYDSe+KjQfrjhcBMxJt/znbvlHd8Pw/Vamaz5EB4Wfhs3SUR3Z9mwRu/P3s3Yg==
-  dependencies:
-    camelcase "^5.3.1"
-    map-obj "^4.0.0"
-    quick-lru "^4.0.1"
 
 camelcase@^5.0.0, camelcase@^5.3.1:
   version "5.3.1"
@@ -2379,14 +2358,6 @@ inherits@2:
   resolved "https://registry.yarnpkg.com/inherits/-/inherits-2.0.4.tgz#0fa2c64f932917c3433a0ded55363aae37416b7c"
   integrity sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==
 
-ip6addr@^0.2.3:
-  version "0.2.3"
-  resolved "https://registry.yarnpkg.com/ip6addr/-/ip6addr-0.2.3.tgz#660df0d27092434f0aadee025aba8337c6d7d4d4"
-  integrity sha512-qA9DXRAUW+lT47/i/4+Q3GHPwZjGt/atby1FH/THN6GVATA6+Pjp2nztH7k6iKeil7hzYnBwfSsxjthlJ8lJKw==
-  dependencies:
-    assert-plus "^1.0.0"
-    jsprim "^1.4.0"
-
 is-accessor-descriptor@^0.1.6:
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz#a9e12cb3ae8d876727eeef3843f8a0897b5c98d6"
@@ -3162,7 +3133,7 @@ json5@^1.0.1:
   dependencies:
     minimist "^1.2.0"
 
-jsprim@^1.2.2, jsprim@^1.4.0:
+jsprim@^1.2.2:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/jsprim/-/jsprim-1.4.1.tgz#313e66bc1e5cc06e438bc1b7499c2e5c56acb6a2"
   integrity sha1-MT5mvB5cwG5Di8G3SZwuXFastqI=
@@ -3295,11 +3266,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.set@^4.3.2:
-  version "4.3.2"
-  resolved "https://registry.yarnpkg.com/lodash.set/-/lodash.set-4.3.2.tgz#d8757b1da807dde24816b0d6a84bea1a76230b23"
-  integrity sha1-2HV7HagH3eJIFrDWqEvqGnYjCyM=
-
 lodash.sortby@^4.7.0:
   version "4.7.0"
   resolved "https://registry.yarnpkg.com/lodash.sortby/-/lodash.sortby-4.7.0.tgz#edd14c824e2cc9c1e0b0a1b42bb5210516a42438"
@@ -3359,25 +3325,12 @@ map-cache@^0.2.2:
   resolved "https://registry.yarnpkg.com/map-cache/-/map-cache-0.2.2.tgz#c32abd0bd6525d9b051645bb4f26ac5dc98a0dbf"
   integrity sha1-wyq9C9ZSXZsFFkW7TyasXcmKDb8=
 
-map-obj@^4.0.0:
-  version "4.2.0"
-  resolved "https://registry.yarnpkg.com/map-obj/-/map-obj-4.2.0.tgz#0e8bc823e2aaca8a0942567d12ed14f389eec153"
-  integrity sha512-NAq0fCmZYGz9UFEQyndp7sisrow4GroyGeKluyKC/chuITZsPyOyC1UJZPJlVFImhXdROIP5xqouRLThT3BbpQ==
-
 map-visit@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/map-visit/-/map-visit-1.0.0.tgz#ecdca8f13144e660f1b5bd41f12f3479d98dfb8f"
   integrity sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=
   dependencies:
     object-visit "^1.0.0"
-
-maxmind@^4.2.0:
-  version "4.3.1"
-  resolved "https://registry.yarnpkg.com/maxmind/-/maxmind-4.3.1.tgz#b20103f19e9fc12e4d1618814380d89a00f65770"
-  integrity sha512-0CxAgwWIwQy4zF1/qCMOeUPleMTYgfnsuIsZ4Otzx6hzON4PCqivPiH6Kz7iWrC++KOGCbSB3nxkJMvDEdWt6g==
-  dependencies:
-    mmdb-lib "1.2.0"
-    tiny-lru "7.0.6"
 
 merge-stream@^2.0.0:
   version "2.0.0"
@@ -3457,11 +3410,6 @@ mkdirp@1.x:
   version "1.0.4"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
-
-mmdb-lib@1.2.0:
-  version "1.2.0"
-  resolved "https://registry.yarnpkg.com/mmdb-lib/-/mmdb-lib-1.2.0.tgz#0ecd93f4942f65a2d09be0502fa9126939606727"
-  integrity sha512-3XYebkStxqCgWJjsmT9FCaE19Yi4Tvs2SBPKhUks3rJJh52oF1AKAd9kei+LTutud3a6RCZ0o2Um96Fn7o3zVA==
 
 ms@2.0.0:
   version "2.0.0"
@@ -3944,11 +3892,6 @@ queue-microtask@^1.2.2:
   version "1.2.2"
   resolved "https://registry.yarnpkg.com/queue-microtask/-/queue-microtask-1.2.2.tgz#abf64491e6ecf0f38a6502403d4cda04f372dfd3"
   integrity sha512-dB15eXv3p2jDlbOiNLyMabYg1/sXvppd8DP2J3EOCQ0AkuSXCW2tP7mnVouVLJKgUMY6yP0kcQDVpLCN13h4Xg==
-
-quick-lru@^4.0.1:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
-  integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
 
 react-is@^17.0.1:
   version "17.0.1"
@@ -4587,11 +4530,6 @@ through@^2.3.8:
   version "2.3.8"
   resolved "https://registry.yarnpkg.com/through/-/through-2.3.8.tgz#0dd4c9ffaabc357960b1b724115d7e0e86a2e1f5"
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
-
-tiny-lru@7.0.6:
-  version "7.0.6"
-  resolved "https://registry.yarnpkg.com/tiny-lru/-/tiny-lru-7.0.6.tgz#b0c3cdede1e5882aa2d1ae21cb2ceccf2a331f24"
-  integrity sha512-zNYO0Kvgn5rXzWpL0y3RS09sMK67eGaQj9805jlK9G6pSadfriTczzLHFXa/xcW4mIRfmlB9HyQ/+SgL0V1uow==
 
 tmpl@1.0.x:
   version "1.0.4"


### PR DESCRIPTION
## Changes

This simple change enables export from the beginning with this plugin, making it extremely powerful as a migration tool across PostHog instances.

See https://github.com/PostHog/posthog.com/issues/1892


## Checklist

-   [ ] Tests for new code
