### PR TITLE
Don't send sent_at with event

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -14,7 +14,7 @@ const plugin: Plugin<ReplicatorMetaInput> = {
         const batch = []
         for (const event of events) {
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
-            const { team_id, now, offset, ...sendableEvent } = { ...event, token: config.project_api_key }
+            const { team_id, now, offset, sent_at, ...sendableEvent } = { ...event, token: config.project_api_key }
             const replication = parseInt(config.replication) || 1
             for (let i = 0; i < replication; i++) {
                 batch.push(sendableEvent)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "posthog-plugin-replicator",
-    "version": "1.1.0",
+    "version": "1.1.1",
     "description": "Replicate PostHog event stream in another PostHog instance",
     "keywords": [
         "posthog",


### PR DESCRIPTION
## Changes

By the time the event gets to `exportEvents`, it will have a `timestamp`. Sending that is all we need to make sure the plugin server on the other side correctly attributes the event to that timestamp. 

See https://github.com/PostHog/plugin-server/blob/85f906a9bf0dfc8df163958b2c20444ed0fafc8d/src/worker/ingestion/process-event.ts#L186. If we strip `sent_at`, we'll just default to the value of `data['timestamp']`, which is desirable. 

Came across this because of historical exports


## Checklist

-   [ ] Tests for new code
