### PR TITLE
fix logging of server errors

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -72,7 +72,9 @@ const plugin: Plugin<ReplicatorMetaInput> = {
                         console.log(`Flushed ${batchDescription} to ${config.host}`)
                     } else if (res.status >= 500) {
                         // Server error, retry the batch later
-                        console.error('Failed to submit ${batchSize} to ${config.host} due to server error', res)
+                        console.error(
+                            `Failed to submit ${batchDescription} to ${config.host} due to server error: ${res.status} ${res.statusText}`
+                        )
                         throw new RetryError(`Server error: ${res.status} ${res.statusText}`)
                     } else {
                         // node-fetch handles 300s internaly, so we're left with 400s here: skip the batch and move forward

--- a/test/test.ts
+++ b/test/test.ts
@@ -1,6 +1,7 @@
 import { RetryError } from '@posthog/plugin-scaffold'
 import { MockedRequest, rest } from 'msw'
 import { setupServer } from 'msw/node'
+import { FetchError } from 'node-fetch'
 
 const plugin = require('../index')
 
@@ -310,7 +311,9 @@ describe('payload contents', () => {
                 })
             )
             await expect(plugin.exportEvents([mockEvent], { config })).rejects.toThrow(RetryError)
-            expect(logSpy).toHaveBeenCalledTimes(1)
+            expect(logSpy).toHaveBeenCalledWith(
+                'Failed to submit 1 event to localhost:8000 due to server error: 500 Internal Server Error'
+            )
             logSpy.mockReset()
         })
 
@@ -318,7 +321,10 @@ describe('payload contents', () => {
             const logSpy = jest.spyOn(console, 'error')
             mswServer.close()
             await expect(plugin.exportEvents([mockEvent], { config })).rejects.toThrow(RetryError)
-            expect(logSpy).toHaveBeenCalledTimes(1)
+            expect(logSpy).toHaveBeenCalledWith(
+                'Failed to submit 1 event to localhost:8000 due to network error',
+                expect.any(FetchError)
+            )
             logSpy.mockReset()
         })
 


### PR DESCRIPTION
## Changes

Fix logging on the 500 case:
  - Fix the string interpolation
  - Log res.status & res.statusText, because res does not have a proper toString

## Checklist

-   [ ] Tests for new code
