### PR TITLE
Added option to ignore events

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -6,7 +6,7 @@ export interface ReplicatorMetaInput {
         host: string
         project_api_key: string
         replication: string
-        eventsToIgnore: string
+        events_to_ignore: string
     }
 }
 
@@ -40,7 +40,11 @@ const reverseAutocaptureEvent = (autocaptureEvent: StrippedEvent) => {
 
 const plugin: Plugin<ReplicatorMetaInput> = {
     exportEvents: async (events, { config }) => {
-        const eventsToIgnore = new Set(config.eventsToIgnore.trim() !== "" ? config.eventsToIgnore.split(',').map(event => event.trim()) : null)
+        const eventsToIgnore = new Set(
+            config.events_to_ignore && config.events_to_ignore.trim() !== ''
+                ? config.events_to_ignore.split(',').map((event) => event.trim())
+                : null
+        )
         const batch = []
         for (const event of events) {
             // skip if event has to be ignored

--- a/index.ts
+++ b/index.ts
@@ -6,6 +6,7 @@ export interface ReplicatorMetaInput {
         host: string
         project_api_key: string
         replication: string
+        eventsToIgnore: string
     }
 }
 
@@ -39,8 +40,14 @@ const reverseAutocaptureEvent = (autocaptureEvent: StrippedEvent) => {
 
 const plugin: Plugin<ReplicatorMetaInput> = {
     exportEvents: async (events, { config }) => {
+        const eventsToIgnore = new Set(config.eventsToIgnore.trim() !== "" ? config.eventsToIgnore.split(',').map(event => event.trim()) : null)
         const batch = []
         for (const event of events) {
+            // skip if event has to be ignored
+            if (eventsToIgnore.has(event.event)) {
+                continue
+            }
+
             // eslint-disable-next-line @typescript-eslint/no-unused-vars
             const { team_id, ip, person: _, ...sendableEvent } = { ...event, token: config.project_api_key }
 

--- a/plugin.json
+++ b/plugin.json
@@ -31,7 +31,7 @@
             "name": "Events to ignore",
             "type": "string",
             "default": "",
-            "hint": "Comma separated list of events to ignore",
+            "hint": "Comma-separated list of events to ignore, e.g. $pageleave, purchase",
             "required": false
         }
     ]

--- a/plugin.json
+++ b/plugin.json
@@ -27,7 +27,7 @@
             "required": false
         },
         {
-            "key": "eventsToIgnore",
+            "key": "events_to_ignore",
             "name": "Events to ignore",
             "type": "string",
             "default": "",

--- a/plugin.json
+++ b/plugin.json
@@ -25,6 +25,14 @@
             "type": "string",
             "default": "1",
             "required": false
+        },
+        {
+            "key": "eventsToIgnore",
+            "name": "Events to ignore",
+            "type": "string",
+            "default": "",
+            "hint": "Comma separated list of events to ignore",
+            "required": false
         }
     ]
 }

--- a/test/data/events-to-ignore.json
+++ b/test/data/events-to-ignore.json
@@ -1,0 +1,29 @@
+[
+    {
+        "distinct_id": "1234",
+        "ip": "127.0.0.1",
+        "event": "my-event-alpha",
+        "properties": {
+            "foo": "bar"
+        },
+        "token": "phc_1234"
+    },
+    {
+        "distinct_id": "1234",
+        "ip": "127.0.0.1",
+        "event": "my-event-beta",
+        "properties": {
+            "foo": "bar"
+        },
+        "token": "phc_1234"
+    },
+    {
+        "distinct_id": "1234",
+        "ip": "127.0.0.1",
+        "event": "my-event-gamma",
+        "properties": {
+            "foo": "bar"
+        },
+        "token": "phc_1234"
+    }
+]

--- a/test/test.ts
+++ b/test/test.ts
@@ -12,7 +12,7 @@ const config = {
     host: captureHost,
     project_api_key: 'test',
     replication: 1,
-    eventsToIgnore: 'my-event-alpha, my-event-beta, my-event-gamma',
+    events_to_ignore: 'my-event-alpha, my-event-beta, my-event-gamma',
 }
 
 const mockEvent = require('./data/event.json')
@@ -356,7 +356,7 @@ describe('payload contents', () => {
                 host: '/invalid',
                 project_api_key: 'test',
                 replication: 1,
-                eventsToIgnore: '',
+                events_to_ignore: '',
             }
             const logSpy = jest.spyOn(console, 'error')
             await expect(plugin.exportEvents([mockEvent], { config: badConfig })).rejects.toThrow(


### PR DESCRIPTION
## Changes
added the option to ignore events for replication
based on implementation used to ignore events for the S3 plugin [(compare)](https://github.com/PostHog/s3-export-plugin/blob/415ba117cd50bdfd210d29d4f9ccc61bffaf1fdf/index.ts#LL90C96-L90C96)
...

## Checklist

-   [x] Tests for new code
