### PR TITLE
feat: Ability to disable geoIP at destination

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -7,6 +7,7 @@ export interface ReplicatorMetaInput {
         project_api_key: string
         replication: string
         events_to_ignore: string
+        disable_geoip: 'Yes' | 'No'
     }
 }
 
@@ -56,11 +57,10 @@ const plugin: Plugin<ReplicatorMetaInput> = {
         }
 
         // eslint-disable-next-line @typescript-eslint/no-unused-vars
-        const { team_id, ip, person: _, ...sendableEvent } = { ...event, token: config.project_api_key }
+        const { team_id, person: _, ...sendableEvent } = { ...event, token: config.project_api_key }
 
-        if (ip) {
-            // Set IP address (originally obtained from capture request headers) in properties
-            sendableEvent.properties.$ip = ip
+        if (config.disable_geoip === 'Yes') {
+            sendableEvent.properties.$geoip_disable = true
         }
 
         const finalSendableEvent =

--- a/plugin.json
+++ b/plugin.json
@@ -33,6 +33,15 @@
             "default": "",
             "hint": "Comma-separated list of events to ignore, e.g. $pageleave, purchase",
             "required": false
+        },
+        {
+            "key": "disable_geoip",
+            "hint": "Add $disable_geoip so that the receiving PostHog instance doesn't try to resolve the IP address.",
+            "name": "Disable Geo IP?",
+            "type": "choice",
+            "choices": ["Yes", "No"],
+            "default": "No",
+            "required": false
         }
     ]
 }

--- a/test/data/autocapture-event.json
+++ b/test/data/autocapture-event.json
@@ -1,8 +1,8 @@
 {
     "distinct_id": "12345",
-    "ip": "127.0.0.1",
     "event": "$autocapture",
     "properties": {
+        "$ip": "127.0.0.1",
         "$os": "Mac OS X",
         "$browser": "Firefox"
     },

--- a/test/data/event.json
+++ b/test/data/event.json
@@ -1,8 +1,8 @@
 {
     "distinct_id": "1234",
-    "ip": "127.0.0.1",
     "event": "my-event",
     "properties": {
+        "$ip": "127.0.0.1",
         "foo": "bar"
     },
     "token": "phc_1234"

--- a/test/data/events-to-ignore.json
+++ b/test/data/events-to-ignore.json
@@ -1,27 +1,27 @@
 [
     {
         "distinct_id": "1234",
-        "ip": "127.0.0.1",
         "event": "my-event-alpha",
         "properties": {
+            "$ip": "127.0.0.1",
             "foo": "bar"
         },
         "token": "phc_1234"
     },
     {
         "distinct_id": "1234",
-        "ip": "127.0.0.1",
         "event": "my-event-beta",
         "properties": {
+            "$ip": "127.0.0.1",
             "foo": "bar"
         },
         "token": "phc_1234"
     },
     {
         "distinct_id": "1234",
-        "ip": "127.0.0.1",
         "event": "my-event-gamma",
         "properties": {
+            "$ip": "127.0.0.1",
             "foo": "bar"
         },
         "token": "phc_1234"


### PR DESCRIPTION
## Changes

If one has ip anonymization enabled, then when the time we get to replicator we won't have an ip that we can re-use. 
We don't want to default to removing geo_ip, because someone might have old project without ip anonymization, but without geoIP and wants to migrate to a new project with geoIP.
Not defaulting due to change of behaviour, though yes would be a better default.

Also: https://posthog.slack.com/archives/C03SQBG3L78/p1696959474035019?thread_ts=1695716736.789489&cid=C03SQBG3L78

## Checklist

-   [ ] Tests for new code
